### PR TITLE
Expose cBPF filter return value

### DIFF
--- a/cbpfc.go
+++ b/cbpfc.go
@@ -11,7 +11,6 @@
 //   - Division by zero is guarded by runtime checks
 //
 // The generated C / eBPF is intended to be embedded into a larger C / eBPF program.
-// Any non zero cBPF return value is considered a match.
 package cbpfc
 
 import (


### PR DESCRIPTION
Expose the actual cBPF return value, instead of just match / no-match.
This allows users to make use of it, for example to only expose that
many bytes of the matching packet using perf.

This simplifies using the ebpf target as well, as the match / nomatch
blocks could previously end up as dead code. There is now a single
ResultLabel, which can't be dead code.