### PR TITLE
Set locked memory in tests, TravisCI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: go
+dist: xenial
+
+env:
+  - GO111MODULE=on CLANG=/usr/bin/clang-6.0
+
+addons:
+  apt:
+    packages:
+      - clang-6.0
+
+script:
+  # gofmt doesn't report any changes
+  - test -z $(gofmt -l ./ | tee /dev/stderr)
+  # tests need to run as root to load XDP programs
+  - sudo -E env "PATH=$PATH" go test ./...

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,5 @@ require (
 	github.com/newtools/ebpf v0.0.0-20190313155020-23e0debb6338
 	github.com/pkg/errors v0.8.1
 	golang.org/x/net v0.0.0-20190320064053-1272bf9dcd53
+	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
 )


### PR DESCRIPTION
Remove locked memory limits in tests, as we would otherwise encounter
EPERM errors on eBPF prog load (depending on the environment).

Add basic TravisCI integration. This doesn't do anything fancy using
qemu / virtme to test specific kernel versions (see branch afabre/ci for
an implementation that doesn't quite work), and instead uses the Ubuntu
Xenial HWE kernel: 4.15.