### PR TITLE
Support cBPF packet length extension

### DIFF
--- a/c.go
+++ b/c.go
@@ -159,6 +159,13 @@ func insnToC(insn instruction, blk *block) (string, error) {
 	case bpf.StoreScratch:
 		return stat("m[%d] = %s;", i.N, regToCSym[i.Src])
 
+	case bpf.LoadExtension:
+		if i.Num != bpf.ExtLen {
+			return "", errors.Errorf("unsupported BPF extension %v", i)
+		}
+
+		return stat("a = data_end - data;")
+
 	case bpf.ALUOpConstant:
 		return stat("a %s= %d;", aluToCOp[i.Op], i.Val)
 	case bpf.ALUOpX:

--- a/cbpfc_test.go
+++ b/cbpfc_test.go
@@ -27,12 +27,25 @@ func TestRaw(t *testing.T) {
 }
 
 func TestExtension(t *testing.T) {
-	_, err := compile([]bpf.Instruction{
-		bpf.LoadExtension{},
-	})
+	// No extensions > 256 right now
+	for i := 0; i < 256; i++ {
+		ext := bpf.Extension(i)
 
-	if err == nil {
-		t.Fatal("load extension accepted", err)
+		_, err := compile([]bpf.Instruction{
+			bpf.LoadExtension{Num: ext},
+			bpf.RetA{},
+		})
+
+		switch ext {
+		case bpf.ExtLen:
+			if err != nil {
+				t.Fatal("ExtLen not accepted", err)
+			}
+		default:
+			if err == nil {
+				t.Fatal("unsupported extension accepted")
+			}
+		}
 	}
 }
 
@@ -172,6 +185,7 @@ func TestInstructionReadsRegA(t *testing.T) {
 		bpf.LoadAbsolute{}:              false,
 		bpf.LoadConstant{Dst: bpf.RegA}: false,
 		bpf.LoadConstant{Dst: bpf.RegX}: false,
+		bpf.LoadExtension{}:             false,
 		bpf.LoadIndirect{}:              false,
 		bpf.LoadMemShift{}:              false,
 		bpf.LoadScratch{Dst: bpf.RegA}:  false,
@@ -204,6 +218,7 @@ func TestInstructionWritesRegA(t *testing.T) {
 		bpf.LoadAbsolute{}:              true,
 		bpf.LoadConstant{Dst: bpf.RegA}: true,
 		bpf.LoadConstant{Dst: bpf.RegX}: false,
+		bpf.LoadExtension{}:             true,
 		bpf.LoadIndirect{}:              true,
 		bpf.LoadMemShift{}:              false,
 		bpf.LoadScratch{Dst: bpf.RegA}:  true,
@@ -236,6 +251,7 @@ func TestInstructionReadsRegX(t *testing.T) {
 		bpf.LoadAbsolute{}:              false,
 		bpf.LoadConstant{Dst: bpf.RegA}: false,
 		bpf.LoadConstant{Dst: bpf.RegX}: false,
+		bpf.LoadExtension{}:             false,
 		bpf.LoadIndirect{}:              true,
 		bpf.LoadMemShift{}:              false,
 		bpf.LoadScratch{Dst: bpf.RegA}:  false,
@@ -268,6 +284,7 @@ func TestInstructionWritesRegX(t *testing.T) {
 		bpf.LoadAbsolute{}:              false,
 		bpf.LoadConstant{Dst: bpf.RegA}: false,
 		bpf.LoadConstant{Dst: bpf.RegX}: true,
+		bpf.LoadExtension{}:             false,
 		bpf.LoadIndirect{}:              false,
 		bpf.LoadMemShift{}:              true,
 		bpf.LoadScratch{Dst: bpf.RegA}:  false,
@@ -300,6 +317,7 @@ func TestInstructionReadsScratch(t *testing.T) {
 		bpf.LoadAbsolute{}:                   false,
 		bpf.LoadConstant{Dst: bpf.RegA}:      false,
 		bpf.LoadConstant{Dst: bpf.RegX}:      false,
+		bpf.LoadExtension{}:                  false,
 		bpf.LoadIndirect{}:                   false,
 		bpf.LoadMemShift{}:                   false,
 		bpf.LoadScratch{Dst: bpf.RegA, N: 3}: true,
@@ -332,6 +350,7 @@ func TestInstructionWritesScratch(t *testing.T) {
 		bpf.LoadAbsolute{}:                   false,
 		bpf.LoadConstant{Dst: bpf.RegA}:      false,
 		bpf.LoadConstant{Dst: bpf.RegX}:      false,
+		bpf.LoadExtension{}:                  false,
 		bpf.LoadIndirect{}:                   false,
 		bpf.LoadMemShift{}:                   false,
 		bpf.LoadScratch{Dst: bpf.RegA, N: 3}: false,

--- a/ebpf.go
+++ b/ebpf.go
@@ -223,6 +223,16 @@ func insnToEBPF(insn instruction, blk *block, opts ebpfOpts) (asm.Instructions, 
 	case bpf.StoreScratch:
 		return ebpfInsn(asm.StoreMem(asm.R10, opts.stackOffset(i.N), opts.reg(i.Src), asm.Word))
 
+	case bpf.LoadExtension:
+		if i.Num != bpf.ExtLen {
+			return nil, errors.Errorf("unsupported BPF extension %v", i)
+		}
+
+		return ebpfInsn(
+			asm.Mov.Reg(opts.regA, opts.PacketEnd),
+			asm.Sub.Reg32(opts.regA, opts.PacketStart),
+		)
+
 	case bpf.ALUOpConstant:
 		return ebpfInsn(aluToEBPF[i.Op].Imm32(opts.regA, int32(i.Val)))
 	case bpf.ALUOpX:

--- a/insn_test.go
+++ b/insn_test.go
@@ -243,6 +243,21 @@ func TestMemShift(t *testing.T) {
 	checkBackends(t, filter(0), []byte{0, 0, 0xF0}, XDPDrop)
 }
 
+func TestLoadExtLen(t *testing.T) {
+	t.Parallel()
+
+	filter := func(pktLen uint32) []bpf.Instruction {
+		return []bpf.Instruction{
+			bpf.LoadExtension{Num: bpf.ExtLen},
+			bpf.JumpIf{Cond: bpf.JumpEqual, Val: pktLen, SkipTrue: 1},
+			bpf.RetConstant{Val: 0},
+			bpf.RetConstant{Val: 1},
+		}
+	}
+
+	checkBackends(t, filter(16), []byte{0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef}, XDPDrop)
+}
+
 // check a OP b == res for both ALUOpConstant and ALUOpX
 func checkAlu(t *testing.T, op bpf.ALUOp, a, b, res uint32) {
 	t.Helper()


### PR DESCRIPTION
cBPF supports extensions for interfacing with the kernel. One of these,
len, loads skb->len into RegA.

This allows us to convert filters using this extension, such as:

    tcpdump "greater 100"