### PR TITLE
travis: Run tests with multple version of Clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,22 @@ language: go
 dist: xenial
 
 env:
-  - GO111MODULE=on CLANG=/usr/bin/clang-6.0
+  global:
+    - GO111MODULE=on
+  matrix:
+    - CLANG=/usr/bin/clang-6.0
+    - CLANG=/usr/bin/clang-7
+    - CLANG=/usr/bin/clang-8
 
 addons:
   apt:
+    sources:
+      - llvm-toolchain-xenial-7
+      - llvm-toolchain-xenial-8
     packages:
       - clang-6.0
+      - clang-7
+      - clang-8
 
 script:
   # gofmt doesn't report any changes

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/cloudflare/cbpfc
 
 require (
-	github.com/newtools/ebpf v0.0.0-20190313155020-23e0debb6338
+	github.com/newtools/ebpf v0.0.0-20190528141928-995442b23c95
 	github.com/pkg/errors v0.8.1
 	golang.org/x/net v0.0.0-20190320064053-1272bf9dcd53
-	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
+	golang.org/x/sys v0.0.0-20190610081024-1e42afee0f76
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/newtools/ebpf v0.0.0-20190313155020-23e0debb6338 h1:68rsjPpj13mbUGhllinENb/lXUBq6dXhlRLf8ymp1oA=
-github.com/newtools/ebpf v0.0.0-20190313155020-23e0debb6338/go.mod h1:eopbi8xx7pp0S2g/ce/pgCcfR4krkn8UrC7z2M9qCHI=
+github.com/newtools/ebpf v0.0.0-20190528141928-995442b23c95 h1:29BUJA5eXsSYGrAdC+zS9tj8ENKhJoy9dZ7dOYNF2Jk=
+github.com/newtools/ebpf v0.0.0-20190528141928-995442b23c95/go.mod h1:H74E4gvXfcsOzgaoPSOuQVoKsWQrg2Xbx6+WybLKvyA=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -7,4 +7,7 @@ golang.org/x/net v0.0.0-20190320064053-1272bf9dcd53 h1:kcXqo9vE6fsZY5X5Rd7R1l7fT
 golang.org/x/net v0.0.0-20190320064053-1272bf9dcd53/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190502175342-a43fa875dd82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190610081024-1e42afee0f76 h1:QSmW7Q3mFdAGjtAd0byXmFJ55inUydyZ4WQmiuItAIQ=
+golang.org/x/sys v0.0.0-20190610081024-1e42afee0f76/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Run the tests using multiple versions of Clang in travis, as they all accept and emit slightly different things.

Update newtools for Clang 8 support.