### PR TITLE
Run tests against kernel cBPF

### DIFF
--- a/c_test.go
+++ b/c_test.go
@@ -32,11 +32,8 @@ func TestFunctionName(t *testing.T) {
 
 const entryPoint = "xdp_filter"
 
-// loadC compiles classic BPF to C, which is compiled with clang
-// XDPDrop on match, XDPPass otherwise
-func loadC(tb testing.TB, insns []bpf.Instruction) *ebpf.ProgramSpec {
-	tb.Helper()
-
+// cBackend compiles classic BPF to C, which is compiled with clang
+func cBackend(tb testing.TB, insns []bpf.Instruction, in []byte) result {
 	elf, err := buildC(insns, entryPoint)
 	if err != nil {
 		tb.Fatal(err)
@@ -48,5 +45,5 @@ func loadC(tb testing.TB, insns []bpf.Instruction) *ebpf.ProgramSpec {
 		tb.Fatal(err)
 	}
 
-	return spec.Programs[entryPoint]
+	return testProg(tb, spec.Programs[entryPoint], in)
 }

--- a/ebpf_test.go
+++ b/ebpf_test.go
@@ -7,11 +7,8 @@ import (
 	"golang.org/x/net/bpf"
 )
 
-// loadEBPF compiles classic BPF to eBPF
-// XDPDrop on match, XDPPass otherwise
-func loadEBPF(tb testing.TB, insns []bpf.Instruction) *ebpf.ProgramSpec {
-	tb.Helper()
-
+// ebpfBacked is backend that compiles classic BPF to eBPF
+func ebpfBackend(tb testing.TB, insns []bpf.Instruction, in []byte) result {
 	prog, err := buildEBPF(insns)
 	if err != nil {
 		tb.Fatal(err)
@@ -19,10 +16,10 @@ func loadEBPF(tb testing.TB, insns []bpf.Instruction) *ebpf.ProgramSpec {
 
 	tb.Logf("\n%v", prog)
 
-	return &ebpf.ProgramSpec{
+	return testProg(tb, &ebpf.ProgramSpec{
 		Name:         "ebpf_filter",
 		Type:         ebpf.XDP,
 		Instructions: prog,
 		License:      "BSD",
-	}
+	}, in)
 }

--- a/insn_test.go
+++ b/insn_test.go
@@ -54,6 +54,7 @@ func TestZeroInitX(t *testing.T) {
 
 func TestZeroInitScratch(t *testing.T) {
 	t.Parallel()
+	t.Skip() // rejected by kernel
 
 	filter := []bpf.Instruction{
 		bpf.LoadScratch{Dst: bpf.RegA, N: 7},
@@ -620,6 +621,7 @@ func checkBackends(t *testing.T, filter []bpf.Instruction, in []byte, expected r
 
 	t.Run("C", check(cBackend))
 	t.Run("eBPF", check(ebpfBackend))
+	t.Run("kernel", check(kernelBackend))
 }
 
 type XDPAction int

--- a/insn_test.go
+++ b/insn_test.go
@@ -2,6 +2,7 @@ package cbpfc
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
 	"os"
 	"testing"
@@ -37,13 +38,18 @@ const (
 )
 
 func TestMain(m *testing.M) {
-	// Remove any locked memory limits so we can load BPF programs
-	err := unix.Setrlimit(unix.RLIMIT_MEMLOCK, &unix.Rlimit{
-		Cur: unix.RLIM_INFINITY,
-		Max: unix.RLIM_INFINITY,
-	})
-	if err != nil {
-		panic(err)
+	// Needed for testing.Short
+	flag.Parse()
+
+	if !testing.Short() {
+		// Remove any locked memory limits so we can load BPF programs
+		err := unix.Setrlimit(unix.RLIMIT_MEMLOCK, &unix.Rlimit{
+			Cur: unix.RLIM_INFINITY,
+			Max: unix.RLIM_INFINITY,
+		})
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	os.Exit(m.Run())

--- a/kernel_test.go
+++ b/kernel_test.go
@@ -1,0 +1,78 @@
+package cbpfc
+
+import (
+	"bytes"
+	"net"
+	"testing"
+	"time"
+	"unsafe"
+
+	"golang.org/x/net/bpf"
+	"golang.org/x/sys/unix"
+)
+
+// kernelBackend is a backend that runs cBPF in the kernel
+func kernelBackend(tb testing.TB, insns []bpf.Instruction, in []byte) result {
+	filter, err := bpf.Assemble(insns)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	// Use a unix socket to test the filter
+	// This doesn't risk interfering with any other network traffic, doesn't require / add special
+	// headers (as would be the case if we used UDP for example) that the XDP tests don't deal with,
+	// and doesn't require any special permissions
+	read, err := net.ListenUnixgram("unixgram", &net.UnixAddr{Name: "", Net: "unixgram"})
+	if err != nil {
+		tb.Fatal(err)
+	}
+	defer read.Close()
+	readConn, err := read.SyscallConn()
+	if err != nil {
+		tb.Fatal(err)
+	}
+	err = readConn.Control(func(fd uintptr) {
+		err := unix.SetsockoptSockFprog(int(fd), unix.SOL_SOCKET, unix.SO_ATTACH_FILTER, &unix.SockFprog{
+			Len:    uint16(len(filter)),
+			Filter: (*unix.SockFilter)(unsafe.Pointer(&filter[0])),
+		})
+		if err != nil {
+			tb.Fatal(err)
+		}
+	})
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	write, err := net.Dial("unixgram", read.LocalAddr().String())
+	if err != nil {
+		tb.Fatal(err)
+	}
+	defer write.Close()
+
+	if _, err := write.Write(in); err != nil {
+		tb.Fatal(err)
+	}
+
+	read.SetDeadline(time.Now().Add(50 * time.Millisecond))
+
+	// SocketFilters only allow matching packets through
+	// If the packet does not match, the only signal we have is the absence of a packet
+	var out [1500]byte
+	n, err := read.Read(out[:])
+	if err != nil {
+		if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
+			return noMatch
+		}
+
+		tb.Fatal(err)
+	}
+
+	// Sanity check we received the right packet
+	// Received packet is truncated to the SocketFilter's return value
+	if !bytes.Equal(in[:n], out[:n]) {
+		tb.Fatalf("Received unexpected packet:\nSent: %v\nGot: %v\n", in, out[:n])
+	}
+
+	return match
+}


### PR DESCRIPTION
The current end to end tests check that the C and eBPF backend behave the same when loaded into the kernel. But they do not check the original cBPF filter behaves the same.
Add another test backend that attaches the unmodified cBPF filter to a unix socket, and runs it on the same test packet.