### PR TITLE
travis: Add clang-9 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,20 @@ env:
     - CLANG=/usr/bin/clang-6.0
     - CLANG=/usr/bin/clang-7
     - CLANG=/usr/bin/clang-8
+    - CLANG=/usr/bin/clang-9
 
 addons:
   apt:
     sources:
       - llvm-toolchain-xenial-7
       - llvm-toolchain-xenial-8
+      - sourceline: 'deb https://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main'
+        key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
     packages:
       - clang-6.0
       - clang-7
       - clang-8
+      - clang-9
 
 script:
   # gofmt doesn't report any changes


### PR DESCRIPTION
Add clang-9 to the versions of clang to test in our travis builds.

Travis-CI hasn't defined a shorthand alias for llvm-toolchain-xenial-9
yet (see https://github.com/travis-ci/apt-source-safelist/pull/414), add
it in manually.