### PR TITLE
Drop uninitialized scratch register support

### DIFF
--- a/c.go
+++ b/c.go
@@ -86,7 +86,7 @@ type COpts struct {
 // non 0 if the packet does match.
 func ToC(filter []bpf.Instruction, opts COpts) (string, error) {
 	if !funcNameRegex.MatchString(opts.FunctionName) {
-		return "", errors.Errorf("invalid FunctioName %s", opts.FunctionName)
+		return "", errors.Errorf("invalid FunctionName %q", opts.FunctionName)
 	}
 
 	blocks, err := compile(filter)

--- a/c.go
+++ b/c.go
@@ -195,9 +195,6 @@ func insnToC(insn instruction, blk *block) (string, error) {
 	case packetGuardIndirect:
 		return stat("if (data + x + %d > data_end) return 0;", i.guard)
 
-	case initializeScratch:
-		return stat("m[%d] = 0;", i.N)
-
 	case checkXNotZero:
 		return stat("if (x == 0) return 0;")
 

--- a/c_test.go
+++ b/c_test.go
@@ -18,8 +18,8 @@ func TestFunctionName(t *testing.T) {
 		if valid && err != nil {
 			t.Fatalf("valid function name %s rejected: %v", name, err)
 		}
-		if !valid && err == nil {
-			t.Fatalf("invalid function name %s not rejected", name)
+		if !valid {
+			requireError(t, err, "invalid FunctionName")
 		}
 	}
 

--- a/cbpfc_test.go
+++ b/cbpfc_test.go
@@ -390,13 +390,7 @@ func TestUninitializedScratch(t *testing.T) {
 	})
 
 	blocks := mustSplitBlocks(t, 1, insns)
-
-	initializeMemory(blocks)
-
-	matchBlock(t, blocks[0], join(
-		[]instruction{{Instruction: initializeScratch{N: 2}}},
-		insns,
-	), nil)
+	requireError(t, initializeMemory(blocks), "instruction 0: ld M[2] reads potentially uninitalized scratch register M[2]")
 }
 
 // scratch reg initialized in one branch, but not the other
@@ -416,15 +410,7 @@ func TestPartiallyUninitializedScratch(t *testing.T) {
 	})
 
 	blocks := mustSplitBlocks(t, 3, insns)
-
-	initializeMemory(blocks)
-
-	matchBlock(t, blocks[0], join(
-		[]instruction{{Instruction: initializeScratch{N: 5}}},
-		insns[:2],
-	), nil)
-	matchBlock(t, blocks[1], insns[2:3], nil)
-	matchBlock(t, blocks[2], insns[3:], nil)
+	requireError(t, initializeMemory(blocks), "instruction 3: ld M[5] reads potentially uninitalized scratch register M[5]")
 }
 
 // Test block splitting

--- a/ebpf.go
+++ b/ebpf.go
@@ -292,9 +292,6 @@ func insnToEBPF(insn instruction, blk *block, opts ebpfOpts) (asm.Instructions, 
 			asm.JGT.Reg(opts.regTmp, opts.PacketEnd, opts.label(noMatchLabel)),
 		)
 
-	case initializeScratch:
-		return ebpfInsn(asm.StoreImm(asm.R10, opts.stackOffset(i.N), 0, asm.Word))
-
 	case checkXNotZero:
 		return ebpfInsn(asm.JEq.Imm(opts.regX, 0, opts.label(noMatchLabel)))
 

--- a/insn_test.go
+++ b/insn_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"golang.org/x/net/bpf"
+
 	// syscall has a wonky RLIM_INFINITY, and no RLIMIT_MEMLOCK
 	"golang.org/x/sys/unix"
 )
@@ -46,18 +47,6 @@ func TestZeroInitX(t *testing.T) {
 
 	filter := []bpf.Instruction{
 		bpf.TXA{},
-		bpf.RetA{},
-	}
-
-	checkBackends(t, filter, []byte{}, noMatch)
-}
-
-func TestZeroInitScratch(t *testing.T) {
-	t.Parallel()
-	t.Skip() // rejected by kernel
-
-	filter := []bpf.Instruction{
-		bpf.LoadScratch{Dst: bpf.RegA, N: 7},
 		bpf.RetA{},
 	}
 


### PR DESCRIPTION
When adding the kernel tests, we discovered that the kernel does not
accept cBPF programs that use scratch registers uninitialized.

Remove the logic we have to zero initialize uninitialized scratch
registers.

Rework some of the tests to check for uninitialized registers instead,
as we seem to be a bit light on such tests.

Fixes #9.

Add a requireError helper for easier tests, and more tests for checking uninitalized registers are properly handled.