### PR TITLE
Memoize guaranteed guard calculation

### DIFF
--- a/cbpfc.go
+++ b/cbpfc.go
@@ -587,11 +587,11 @@ func addBlockGuards(block *block, currentGuard packetGuard, opts packetGuardOpts
 func guaranteedGuard(targets map[pos]*block, opts packetGuardOpts) packetGuard {
 
 	// Inner implementation - Uses memoization
-	return guaranteedGuardCached(targets, opts, make(map[pos]packetGuard))
+	return guaranteedGuardCached(targets, opts, make(map[*block]packetGuard))
 }
 
 // 'cache' is used in order to not calculate guard more than once for the same block.
-func guaranteedGuardCached(targets map[pos]*block, opts packetGuardOpts, cache map[pos]packetGuard) packetGuard {
+func guaranteedGuardCached(targets map[pos]*block, opts packetGuardOpts, cache map[*block]packetGuard) packetGuard {
 	targetGuards := []packetGuard{}
 
 	for _, target := range targets {
@@ -599,7 +599,7 @@ func guaranteedGuardCached(targets map[pos]*block, opts packetGuardOpts, cache m
 		if blockNeverMatches(target) {
 			continue
 		}
-		if guard, ok := cache[target.id]; ok {
+		if guard, ok := cache[target]; ok {
 			targetGuards = append(targetGuards, guard)
 			continue
 		}
@@ -618,7 +618,7 @@ func guaranteedGuardCached(targets map[pos]*block, opts packetGuardOpts, cache m
 			insnsGuard = guaranteed
 		}
 
-		cache[target.id] = insnsGuard
+		cache[target] = insnsGuard
 
 		targetGuards = append(targetGuards, insnsGuard)
 	}

--- a/cbpfc.go
+++ b/cbpfc.go
@@ -592,6 +592,10 @@ func guaranteedGuard(targets map[pos]*block, opts packetGuardOpts, cache map[pos
 		if blockNeverMatches(target) {
 			continue
 		}
+		if guard, ok := cache[target.id]; ok {
+			targetGuards = append(targetGuards, guard)
+			continue
+		}
 
 		insnsCovered, insnsGuard := opts.requiredGuard(target.insns)
 
@@ -601,17 +605,13 @@ func guaranteedGuard(targets map[pos]*block, opts packetGuardOpts, cache map[pos
 			continue
 		}
 
-		var guaranteed packetGuard
-		if memoizedValue, exists := cache[target.id]; exists {
-			guaranteed = memoizedValue
-		} else {
-			guaranteed = guaranteedGuard(target.jumps, opts, cache)
-			cache[target.id] = guaranteed
-		}
+		guaranteed := guaranteedGuard(target.jumps, opts, cache)
 
 		if guaranteed > insnsGuard {
 			insnsGuard = guaranteed
 		}
+
+		cache[target.id] = insnsGuard
 
 		targetGuards = append(targetGuards, insnsGuard)
 	}


### PR DESCRIPTION
I was very happy to find cbpfc, as it is simple to use and very concise. When playing around with it for my use case, I found out that it hangs when trying to compile filters that were on the larger side. After a bit of debugging I noticed that the function that finds the guaranteed guard is doing too many iterations, and with help from @shaharyarn we implemented a simple (if somewhat crude) solution. 

commit message:
For large graphs (i.e. large cbpfc programs) compilation
process was long (unusably so), since the guaranteed guard
was calculated by traversing "upwards" in the graph once for each node,
recursively.
I added (simple) memoization to remedy that.