### PR TITLE
ebpf: Fix stack offsets for scratch 0

### DIFF
--- a/ebpf.go
+++ b/ebpf.go
@@ -52,7 +52,8 @@ type EBPFOpts struct {
 	// Must be different to PacketStart and PacketEnd, but Result can be reused.
 	Working [4]asm.Register
 
-	// StackOffset is the first stack offset that can be used.
+	// StackOffset is the number of bytes of stack already used / reserved.
+	// R10 (ebpf frame pointer) + StackOffset will be used as the top of the stack.
 	StackOffset int
 
 	// LabelPrefix is the prefix to prepend to labels used internally.
@@ -90,8 +91,10 @@ func (e ebpfOpts) label(name string) string {
 	return fmt.Sprintf("%s_%s", e.LabelPrefix, name)
 }
 
-func (e ebpfOpts) stackOffset(n int) int16 {
-	return -int16(e.StackOffset + n*4)
+// eBPF stack address offset for BPF scratch slot scracth.
+func (e ebpfOpts) stackOffset(scratch int) int16 {
+	// First usable stack space ends at StackOffset.
+	return -int16(e.StackOffset + (scratch+1)*4)
 }
 
 // ToEBF converts a cBPF filter to eBPF.

--- a/insn_test.go
+++ b/insn_test.go
@@ -159,6 +159,26 @@ func TestLoadIndirect(t *testing.T) {
 	checkBackends(t, filter(0xDEAFBEEF, 4), []byte{0, 0, 0, 0xDE, 0xAD, 0xBE, 0xEF}, noMatch)
 }
 
+// The 0 scratch slot is usable.
+func TestScratchZero(t *testing.T) {
+	t.Parallel()
+
+	filter := []bpf.Instruction{
+		bpf.LoadConstant{Dst: bpf.RegA, Val: 4},
+		bpf.StoreScratch{Src: bpf.RegA, N: 0},
+
+		// clobber the reg in the mean time
+		bpf.LoadConstant{Dst: bpf.RegA, Val: 0},
+
+		bpf.LoadScratch{Dst: bpf.RegA, N: 0},
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: 4, SkipTrue: 1},
+		bpf.RetConstant{Val: 0},
+		bpf.RetConstant{Val: 1},
+	}
+
+	checkBackends(t, filter, nil, match)
+}
+
 func TestScratchA(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
We used incorrect eBPF stack offsets for BPF scratch regs.
The stack pointer points to the top of the stack, so this corresponds to
the "end" address of scratch 0, and not the start address.