### PR TITLE
Fix jump calculation

### DIFF
--- a/cbpfc.go
+++ b/cbpfc.go
@@ -38,10 +38,10 @@ var condToInverse = map[bpf.JumpTest]bpf.JumpTest{
 }
 
 // pos stores the absolute position of a cBPF instruction
-type pos uint
+type pos uint32
 
 // skips store cBPF jumps, which are relative
-type skip uint
+type skip uint32
 
 // instruction wraps a bpf instruction with it's
 // original position


### PR DESCRIPTION
Currently, an error is triggered when calling ToEBPF() on cBPF instructions generated by the filter "ip6 protochain 58":

    $ tcpdump -dd ip6 protochain 58 | cat -n
    Warning: assuming Ethernet
         1	{ 0x28, 0, 0, 0x0000000c },
         2	{ 0x15, 0, 33, 0x000086dd },
         3	{ 0x30, 0, 0, 0x00000014 },
         4	{ 0x1, 0, 0, 0x00000028 },
         5	{ 0x15, 27, 0, 0x0000003a },
         6	{ 0x15, 26, 0, 0x0000003b },
         7	{ 0x15, 3, 0, 0x00000000 },
         8	{ 0x15, 2, 0, 0x0000003c },
         9	{ 0x15, 1, 0, 0x0000002b },
        10	{ 0x15, 0, 9, 0x0000002c },
        11	{ 0x50, 0, 0, 0x0000000e },
        12	{ 0x2, 0, 0, 0x00000000 },
        13	{ 0x50, 0, 0, 0x0000000f },
        14	{ 0x4, 0, 0, 0x00000001 },
        15	{ 0x24, 0, 0, 0x00000008 },
        16	{ 0xc, 0, 0, 0x00000000 },
        17	{ 0x7, 0, 0, 0x00000000 },
        18	{ 0x60, 0, 0, 0x00000000 },
        19	{ 0x5, 0, 0, 0xfffffff1 },
        20	{ 0x15, 0, 12, 0x00000033 },
        21	{ 0x87, 0, 0, 0x00000000 },
        22	{ 0x50, 0, 0, 0x0000000e },
        23	{ 0x2, 0, 0, 0x00000000 },
        24	{ 0x87, 0, 0, 0x00000000 },
        25	{ 0x4, 0, 0, 0x00000001 },
        26	{ 0x7, 0, 0, 0x00000000 },
        27	{ 0x50, 0, 0, 0x0000000e },
        28	{ 0x4, 0, 0, 0x00000002 },
        29	{ 0x24, 0, 0, 0x00000004 },
        30	{ 0x7, 0, 0, 0x00000000 },
        31	{ 0x60, 0, 0, 0x00000000 },
        32	{ 0x5, 0, 0, 0xffffffe4 },
        33	{ 0x4, 0, 0, 0x00000000 },
        34	{ 0x15, 0, 1, 0x0000003a },
        35	{ 0x6, 0, 0, 0x00040000 },
        36	{ 0x6, 0, 0, 0x00000000 },

Line 19 {0x5, 0, 0, 0xfffffff1} is a "JA 0xfffffff1" instruction. When cbpfc.ToEBPF() attempts to translate this jump, it miscalculates the destination due to the incorrect type of the pos variable.

The bug arises because pos is currently of type uint (which is uint64 on 64-bit systems), whereas it should be uint32 to correctly emulate cBPF's 32-bit overflow semantics. Instead of computing the correct jump destination as:

    uint32(18 + 1 + 0xfffffff1) = 4

It evaluates to:

    18 + 1 + 0xfffffff1 = 0x100000004 (due to 64-bit addition)

As a result, the jump target becomes invalid, and ToEBPF() errors out with:

    instruction 18: ja 4294967281 flows past last instruction

This patch changes the type of pos to uint32, ensuring correct overflow behavior and jump target computation consistent with cBPF expectations.