### PR TITLE
Fix ToC to respect NoInline argument

### DIFF
--- a/c.go
+++ b/c.go
@@ -106,8 +106,9 @@ func ToC(filter []bpf.Instruction, opts COpts) (string, error) {
 	}
 
 	fun := cFunction{
-		Name:   opts.FunctionName,
-		Blocks: make([]cBlock, len(blocks)),
+		Name:     opts.FunctionName,
+		NoInline: opts.NoInline,
+		Blocks:   make([]cBlock, len(blocks)),
 	}
 
 	// Compile blocks to C

--- a/c_test.go
+++ b/c_test.go
@@ -2,6 +2,7 @@ package cbpfc
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/cilium/ebpf"
@@ -28,6 +29,22 @@ func TestFunctionName(t *testing.T) {
 	checkName(t, "0foo\nfoo", false)
 	checkName(t, "foo_bar2", true)
 	checkName(t, "a2", true)
+}
+
+func TestToCNoInline(t *testing.T) {
+	elf, err := ToC([]bpf.Instruction{
+		bpf.RetConstant{Val: 1},
+	}, COpts{
+		FunctionName: "filter",
+		NoInline:     true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(elf, "__always_inline__") {
+		t.Fatal("generated C source should not contain __always_inline__ when NoInline is true")
+	}
 }
 
 func TestNoInline(t *testing.T) {


### PR DESCRIPTION
Previously the ToC function silently ignored the NoInline option passed
as argument to it. Even though the template correctly considered it, the
value specified by the caller was not being passed down to the template
execution function.